### PR TITLE
Clean up Fmap imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/*.js
 docs/*.css
 html
 mlihtml
+
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: Makefile.coq
 
 clean::
 	if [ -e Makefile.coq ]; then $(MAKE) -f Makefile.coq cleanall; fi
-	$(RM) $(wildcard Makefile.coq Makefile.coq.conf) 
+	$(RM) $(wildcard Makefile.coq Makefile.coq.conf)
 
 Makefile.coq:
 	coq_makefile -f _CoqProject -o Makefile.coq

--- a/staged/HeapF.v
+++ b/staged/HeapF.v
@@ -1,9 +1,9 @@
 
 From SLF Require Export LibString LibCore.
 From SLF Require Export LibSepTLCbuffer.
-From SLF Require Import LibSepFmap.
-Module Fmap := LibSepFmap.
 From SLF Require LibSepSimpl.
+
+From Staged Require Import LibFmap.
 
 Module Type Params.
 
@@ -13,8 +13,10 @@ End Params.
 
 
 Module HeapSetup (V : Params).
+
 Import V.
 Local Notation val := V.value.
+
 Set Implicit Arguments.
 
 Definition loc : Type := nat.

--- a/staged/LibFmap.v
+++ b/staged/LibFmap.v
@@ -1,8 +1,8 @@
 
-From SLF Require Import LibCore LibSepFmap.
-Module Fmap := LibSepFmap.
+From SLF Require Import LibCore.
+From SLF Require Export LibSepFmap.
 
-(* extra things to add to SLF's formalization *)
+Module Fmap := LibSepFmap.
 
 Lemma fmap_disjoint_indom : forall (A B: Type) (h1 h2 : fmap A B) x,
   disjoint h1 h2 -> indom h1 x -> not (indom h2 x).
@@ -13,26 +13,26 @@ Proof.
 Qed.
 
 Lemma fmap_indom_empty : forall A B (k:A),
-  ~ Fmap.indom (@Fmap.empty A B) k.
+  ~ indom (@empty A B) k.
 Proof.
   intros.
   unfold not; intros.
   hnf in H.
-  unfold Fmap.empty in H.
+  unfold empty in H.
   apply H.
   simpl.
   reflexivity.
 Qed.
 
 Lemma fmap_read_update : forall A B {IB:Inhab B} (k:A) (v:B) m,
-  ~ Fmap.indom m k ->
-  Fmap.read (Fmap.update m k v) k = v.
+  ~ indom m k ->
+  read (update m k v) k = v.
 Proof.
   intros.
-  unfold Fmap.update.
-  rewrite Fmap.read_union_l.
-  apply Fmap.read_single.
-  apply Fmap.indom_single.
+  unfold update.
+  rewrite read_union_l.
+  apply read_single.
+  apply indom_single.
 Qed.
 
 #[global]

--- a/staged/Logic.v
+++ b/staged/Logic.v
@@ -6,12 +6,8 @@ From Coq Require Morphisms Program.Basics.
 Set Warnings "-notation-incompatible-prefix".
 From Staged Require Export HeapF.
 Set Warnings "notation-incompatible-prefix".
-
-From SLF Require LibSepFmap.
-Module Fmap := LibSepFmap.
-Export (ltac.notations, hints, notations) LibSepFmap.
-
-From Staged Require Export Extra ExtraTactics.
+From Staged Require Export LibFmap.
+From Staged Require Export ExtraTactics.
 
 Local Open Scope string_scope.
 (* Local Open Scope nat_scope. *)
@@ -1085,7 +1081,7 @@ Proof.
   specialize (H1 hp hr H0).
   forward H1. fmap_eq.
   forward H1. fmap_disjoint.
-  
+
   constructor.
   exists h3.
   exists r1.
@@ -1345,7 +1341,7 @@ Proof.
     intuition.
     constructor. exists v.
     intuition. }
-Qed.  
+Qed.
 
 Lemma norm_seq_ex_reassoc : forall A f f1,
   bientails (fex (fun (x:A) => f x);; f1) (fex (fun (x:A) => f x;; f1)).
@@ -1381,7 +1377,7 @@ Proof.
   constructor. intros v.
   specialize (H1 v).
   constructor. exists h3. exists r1.
-  intuition. 
+  intuition.
 Qed.
 
 Lemma norm_ent_ent_pure_comm: forall H P,


### PR DESCRIPTION
The imported `LibSepFmap` and module alias `Fmap := LibSepFmap` creates too many identifiers when using `Search` when search for lemmas.

All definitions in to `LibSepFmap` is now exported under `staged/LibFMap`. We also provide an alias for `LibSepFmap` in `LibFmap`. Now search result only shows two results:
- Fmap.<lemma name>: due to the alias `FMap := LibSepFmap`.
- <lemma name>: due to the exported `LibSepFmap` in `LibFmap`.

We also move extra lemmas about fmap under `LibFmap` as well, for consistency.